### PR TITLE
Handling error messages in the power files

### DIFF
--- a/power-script.py
+++ b/power-script.py
@@ -65,6 +65,8 @@ for i in range(0, len(node_list)):
             columns =['time','power']
             df=pd.read_csv(file_to_open,sep=',',header=None,names=columns)
             times=pd.to_datetime(df['time'],format='%H:%M:%S').dt.time
+            #Replace any error messages with NaN so the averaging can work
+            df['power'] = pd.to_numeric(df['power'], errors='coerce')
             #excluded first 2 and last data point
             #power_sum = df.loc[(df['time'] > time_start) & (df['time'] < time_end), 'power'].mean()
             job_df = df.loc[(df['time'] > time_start) & (df['time'] < time_end)].iloc[2:-1] 


### PR DESCRIPTION
Sometimes in the power files there are lines like:` 00:12:01,ERROR: It could not get all result of ipmitool command.` and so the power script throws an error like this when trying to calculate the average power, because not all the values are numbers:
```
in <module>
    power_sum = job_df['power'].mean()
....
raise TypeError(f"Could not convert string '{x}' to numeric")
```
I added a line to the power script to replace those error messages with NaN, and then the averaging works ok.